### PR TITLE
Better eval command and base URL management

### DIFF
--- a/base/Request.js
+++ b/base/Request.js
@@ -4,11 +4,7 @@ const fetch = require('node-fetch');
 
 class Request extends Command {
   getBaseURL() {
-    if (process.env.NODE_ENV !== 'production') {
-      return "http://localhost:3000";
-    } else {
-      return "https://opc.ai";
-    }
+    return process.env.OPC_BASE_URL || "https://opc.ai";
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
   "dependencies": {
     "better-sqlite-pool": "github:eslachance/better-sqlite-pool",
     "chalk": "^2.4.1",
-    "discord.js": "^11.4.2",
+    "discord.js": "git+https://github.com/discordjs/discord.js.git",
     "enmap": "^4.3.2",
+    "js-beautify": "^1.8.9",
     "klaw": "^2.1.1",
     "moment": "^2.22.2",
     "moment-duration-format": "^2.2.2",
     "node-fetch": "^2.3.0",
-    "readline-sync": "^1.4.9"
+    "readline-sync": "^1.4.9",
+    "util": "^0.11.1"
   }
 }


### PR DESCRIPTION
- [x] Eval command enhanced
- [x] Base URL defaults to prod API, unless overridden by `process.env.OPC_BASE_URL`